### PR TITLE
macOS/Linux client not connecting bug

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -55,8 +55,9 @@ func main() {
 			slog.Error("Username cannot be empty")
 			slog.Info("Please enter username: ")
 			fmt.Scan(username)
-			break
+			continue
 		}
+		break
 	}
 
 	if *listenAt == "" {


### PR DESCRIPTION
fixed bug for linux/macOS where in case of not entering the username for bin/client the client would hang indefinitely causing the client to enter the for loop continuously - could not be caught in windows because the USER env variable does not exist causing the client on windows to prompt the user correctly